### PR TITLE
Import Algorithm - Fixes Windows 10 Install Errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <string.h>
 #include <sstream>
+#include <algorithm>
 using namespace std;
 
 


### PR DESCRIPTION
We had some trouble installing our Python Django project on machines running Windows 10.

We discovered that explicitly importing `<algorithm>` into main.cpp fixes the issue.

Found this fix from a different author who made this commit on their fork:

https://github.com/JoshC8C7/pylcs/commit/3c5a890f767c8045f6a886c9b4480b3910ac467f